### PR TITLE
Update FetchDatastoreEntry to use correct key for last update timestamp

### DIFF
--- a/pkg/website/read.go
+++ b/pkg/website/read.go
@@ -95,7 +95,7 @@ func GetFirstCreationTimestamp(network *config.NetworkInfos, websiteAddress stri
 func GetLastUpdateTimestamp(network *config.NetworkInfos, websiteAddress string) (uint64, error) {
 	client := node.NewClient(network.NodeURL)
 
-	lastUpdateTimestampResponse, err := node.FetchDatastoreEntry(client, websiteAddress, convert.ToBytes(firstCreationTimestampKey))
+	lastUpdateTimestampResponse, err := node.FetchDatastoreEntry(client, websiteAddress, convert.ToBytes(lastUpdateTimestampKey))
 	if err != nil {
 		return 0, fmt.Errorf("fetching website last update timestamp: %w", err)
 	}


### PR DESCRIPTION
Shoutout to @pivilartisant for finding and fixing this bug first (I just made this PR to have it on main faster)