### PR TITLE
Fix 404 error on error pages when a resource is specified

### DIFF
--- a/server/int/api/local.go
+++ b/server/int/api/local.go
@@ -13,6 +13,19 @@ func localHandler(w http.ResponseWriter, zipBytes []byte, resourceName string) {
 		resourceName = "index.html"
 	}
 
+	isPresent, err := zipper.VerifyFilePresence(zipBytes, resourceName)
+	if err != nil {
+		logger.Errorf("localHandler: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	// If requested resource is not present, it might be the original requested resource.
+	// In this case, we try to serve the index.html file of the zip.
+	if !isPresent {
+		logger.Debugf("localHandler: Resource %s not found in zip, changing to index.html", resourceName)
+		resourceName = "index.html"
+	}
+
 	content, err := zipper.ReadFileFromZip(zipBytes, resourceName)
 	if err != nil {
 		logger.Warnf("File not found: %t", zipper.IsNotFoundError(err, resourceName))

--- a/server/int/api/local.go
+++ b/server/int/api/local.go
@@ -14,7 +14,7 @@ func localHandler(w http.ResponseWriter, zipBytes []byte, resourceName string) {
 	}
 
 	isPresent, err := zipper.VerifyFilePresence(zipBytes, resourceName)
-	if err != nil {
+	if err != nil && !zipper.IsNotFoundError(err, resourceName) {
 		logger.Errorf("localHandler: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 	}

--- a/server/int/zipper/zipper.go
+++ b/server/int/zipper/zipper.go
@@ -63,5 +63,5 @@ func VerifyFilePresence(zipFile []byte, fileName string) (bool, error) {
 		}
 	}
 
-	return false, fmt.Errorf("%s not found in zip file", fileName)
+	return false, fmt.Errorf(notFoundErrorTemplate, fileName)
 }

--- a/server/int/zipper/zipper.go
+++ b/server/int/zipper/zipper.go
@@ -49,14 +49,15 @@ func IsValidZip(zipFile []byte) bool {
 	return err == nil
 }
 
-func VerifyFilePresence(filePath string, fileName string) (bool, error) {
-	reader, err := zip.OpenReader(filePath)
-	if err != nil {
-		return false, fmt.Errorf("provided filepath is not a valid zip file: %w", err)
-	}
-	defer reader.Close()
+func VerifyFilePresence(zipFile []byte, fileName string) (bool, error) {
+	reader := bytes.NewReader(zipFile)
 
-	for _, file := range reader.File {
+	zipReader, err := zip.NewReader(reader, int64(reader.Len()))
+	if err != nil {
+		return false, fmt.Errorf("failed to initiate zip reader: %v", err)
+	}
+
+	for _, file := range zipReader.File {
 		if file.Name == fileName {
 			return true, nil
 		}


### PR DESCRIPTION
When a resource is specified on an error page, for example, http://mmmm.localhost:8080 is supposed to show the "MNS not found" error page (unless someone tool the `mmmm` domain 🙃). If the url as something after the port, for example http://mmmm.localhost:8080/test , it result in a web browser 404 error which is ugly and bad. We should always show the deweb error page
